### PR TITLE
Appropriate tab behaviour for specific filetypes

### DIFF
--- a/lua/config/set.lua
+++ b/lua/config/set.lua
@@ -1,3 +1,4 @@
+-- for ease of use
 local set = vim.opt
 set.guicursor = ""
 
@@ -5,7 +6,7 @@ set.guicursor = ""
 set.nu = true
 set.relativenumber = true
 
--- all the tabs shenanigans
+-- default tab settings
 set.expandtab = false
 set.smarttab = true
 set.shiftwidth = 4
@@ -38,5 +39,13 @@ set.undofile = true
 -- looks nice
 set.termguicolors = true
 set.laststatus = 3
-
 vim.g.mapleader = " "
+
+-- for specific spacing behaviour
+vim.cmd[[
+    augroup FileTypeTabs
+        autocmd!
+        autocmd FileType lua,yaml lua require('tabber').set_tab_options()
+    augroup END
+]]
+

--- a/lua/config/tabber.lua
+++ b/lua/config/tabber.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 M.set_tab_options = function()
-  -- Set default values
+  -- set default values
   vim.o.tabstop = 4
   vim.o.shiftwidth = 4
   vim.o.softtabstop = 4
@@ -12,17 +12,14 @@ M.set_tab_options = function()
     { 'yaml', 2, 2, 2, true },
   }
 
-  -- get the current filetype using both methods
+  -- get the current filetype
   local current_filetype = vim.bo.filetype
-  print("filetype found:", current_filetype)
 
   -- check if the current filetype is in the specified list
   for _, setting in ipairs(exceptions) do
       local exception_filetype, tabstop, shiftwidth, softtabstop, enable = unpack(setting)
-      print("exception_filetype:", exception_filetype)
 
       if current_filetype == exception_filetype and enable then
-          print("found it!")
 
           -- set buffer-local options directly
           vim.bo.tabstop = tabstop
@@ -30,7 +27,6 @@ M.set_tab_options = function()
           vim.bo.softtabstop = softtabstop
           vim.bo.expandtab = true
 
-          print("settings applied!")
           return
       end
   end

--- a/lua/config/tabber.lua
+++ b/lua/config/tabber.lua
@@ -1,0 +1,40 @@
+local M = {}
+
+M.set_tab_options = function()
+  -- Set default values
+  vim.o.tabstop = 4
+  vim.o.shiftwidth = 4
+  vim.o.softtabstop = 4
+  vim.o.expandtab = false
+
+  local exceptions = {
+    { 'lua', 2, 2, 2, true },
+    { 'yaml', 2, 2, 2, true },
+  }
+
+  -- get the current filetype using both methods
+  local current_filetype = vim.bo.filetype
+  print("filetype found:", current_filetype)
+
+  -- check if the current filetype is in the specified list
+  for _, setting in ipairs(exceptions) do
+      local exception_filetype, tabstop, shiftwidth, softtabstop, enable = unpack(setting)
+      print("exception_filetype:", exception_filetype)
+
+      if current_filetype == exception_filetype and enable then
+          print("found it!")
+
+          -- set buffer-local options directly
+          vim.bo.tabstop = tabstop
+          vim.bo.shiftwidth = shiftwidth
+          vim.bo.softtabstop = softtabstop
+          vim.bo.expandtab = true
+
+          print("settings applied!")
+          return
+      end
+  end
+end
+
+return M
+


### PR DESCRIPTION
File types such as Lua or YAML use 2-space indentation instead of traditional to C-like languages styling of 4-space tabs.

To address the issue of having to always insert spaces manually, I wanted to introduce a functionality that would detect when a  particular file, that uses some non-C standard styling guidelines is in edition and change the tab behavior accordingly.
Then, if the buffer is changed back to the non-exception file type, the setting would be reverted back to normal.